### PR TITLE
Add DrupalContext to available contexts in the "general" test suite

### DIFF
--- a/tests/behat/behat.yml
+++ b/tests/behat/behat.yml
@@ -12,6 +12,7 @@ default:
         - "%paths.base%/features/general"
       contexts:
         - Drupal\DrupalExtension\Context\MinkContext
+        - Drupal\DrupalExtension\Context\DrupalContext
   extensions:
     Behat\MinkExtension:
       goutte:


### PR DESCRIPTION
#9 
On branch feature-9-add-drupal-context-to-general-test-suite
Changes to be committed:
	modified:   tests/behat/behat.yml