### PR TITLE
Adding missing WEB_DOCUMENT_ROOT env variable to web server service.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,7 @@ services:
       - ./:/var/www/html:cached # User-guided caching      
     environment:
       WEB_ALIAS_DOMAIN: 'www.${HOSTNAME}'
+      WEB_DOCUMENT_ROOT: '/var/www/html/docroot'
     depends_on:
       - php
       - db


### PR DESCRIPTION
https://github.com/codementality/drupal-project-build/issues/18

On branch feature-18-add-missing-env-var-to-docker-compose

Changes to be committed:
	modified:   docker-compose.yml